### PR TITLE
versioning on server side added

### DIFF
--- a/Updater/AppConstants.cs
+++ b/Updater/AppConstants.cs
@@ -9,6 +9,6 @@ namespace Updater;
 public class AppConstants
 {
     public const string ToolsDirectory = @"C:\temp";
-    public const string ServerIP = "10.128.4.16";
+    public const string ServerIP = "10.32.5.145";
     public const string Port = "60091";
 }

--- a/Updater/FileContent.cs
+++ b/Updater/FileContent.cs
@@ -7,9 +7,11 @@
 * 
 * Project     = Lab Monitoring Software
 *
-* Description = 
+* Description = This class represents the content and metadata of a file, including its name, serialized content, and version.
+* 
 *****************************************************************************/
 
+using System;
 using System.Xml.Serialization;
 
 namespace Updater;
@@ -18,12 +20,15 @@ namespace Updater;
 public class FileContent
 {
     // Parameterless constructor is required for XML serialization
-    public FileContent() { }
+    public FileContent() {
+        Version = "1.0";
+    }
 
-    public FileContent(string? fileName, string? serializedContent)
+    public FileContent(string? fileName, string? serializedContent, string version = "1.0")
     {
         FileName = fileName;
         SerializedContent = serializedContent;
+        Version = version;
     }
 
     [XmlElement("FileName")]
@@ -32,8 +37,27 @@ public class FileContent
     [XmlElement("SerializedContent")]
     public string? SerializedContent { get; set; }
 
+    [XmlElement("Version")]
+    public string? Version { get; set; } = "1.0";
     public override string ToString()
     {
-        return $"FileName: {FileName ?? "N/A"}, Content Length: {SerializedContent?.Length ?? 0}";
+        return $"FileName: {FileName ?? "N/A"}, Content Length: {SerializedContent?.Length ?? 0}, Version: {Version}";
+    }
+
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is FileContent other)
+        {
+            return FileName == other.FileName &&
+                   SerializedContent == other.SerializedContent &&
+                   Version == other.Version;
+        }
+        return false;
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(FileName, SerializedContent, Version);
     }
 }


### PR DESCRIPTION
For versioning:
(On server side)
HandleNewFileVersion: This method processes incoming files. It checks if a file with the same content already exists. If it does, it compares the versions and updates the file if the new version is higher. If no such file exists, it adds the new file.

HandleVersionConflict: This method resolves version conflicts by replacing an older file with the new one if the new version is higher, then broadcasts the updated file to clients.

ProcessNewFile: If no version conflict exists, it writes the new file to disk, adds it to the list of existing files, and broadcasts the new file to clients.

BroadcastNewVersion: This method broadcasts a new or updated file to all clients 
