### PR TITLE
Resolving File Naming Conflict: Handle Client-Server Sync Issues for Files with Same Name but Different Content

### DIFF
--- a/Updater/DataPacket.cs
+++ b/Updater/DataPacket.cs
@@ -21,6 +21,7 @@ public class DataPacket
     public enum PacketType
     {
         SyncUp,        // No files
+        InvalidSync,   // No files
         Metadata,      // single file
         Differences,   // multiple files
         ClientFiles,   // multiple files

--- a/Updater/DirectoryMetadataComparer.cs
+++ b/Updater/DirectoryMetadataComparer.cs
@@ -59,6 +59,7 @@ namespace Updater
 
             CheckForRenamesAndMissingFiles(metadataB, hashToFileA);
             CheckForOnlyInAFiles(metadataA, hashToFileB);
+            CheckForSameNameDifferentHash(metadataA, metadataB);
         }
 
         /// <summary>

--- a/Updater/DirectoryMetadataComparer.cs
+++ b/Updater/DirectoryMetadataComparer.cs
@@ -27,8 +27,8 @@ namespace Updater
         [XmlElement("UniqueClientFiles")]
 
         public List<string> UniqueClientFiles { get; private set; } = new List<string>();
+        public List<string> InvalidSyncUpFiles { get; private set; } = new List<string>();
 
-  
         // Parameterless constructor for XML serialization
         public DirectoryMetadataComparer() { }
 
@@ -124,6 +124,36 @@ namespace Updater
                     UniqueServerFiles.Add(fileA.FileName);
                 }
             }
+        }
+
+        /// <summary>
+        /// Checks for files in directory A and B that have the same name but different hashes.
+        /// </summary>
+        /// <param name="metadataA">Dir. A's metadata</param>
+        /// <param name="metadataB">Dir. B's metadata</param>
+        private void CheckForSameNameDifferentHash(List<FileMetadata> metadataA, List<FileMetadata> metadataB)
+        {
+            // Iterate over each file in directory A
+            foreach (FileMetadata fileA in metadataA)
+            {
+                // Find a file in directory B that has the same name as fileA
+                FileMetadata fileB = metadataB.FirstOrDefault(fb => fb.FileName == fileA.FileName);
+
+                if (fileB != null && fileA.FileHash != fileB.FileHash)
+                {
+                    // Found files with the same name but different hashes
+                    InvalidSyncUpFiles.Append(fileA.FileName);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Validates whether directories can be synced.
+        /// </summary>
+        public bool ValidateSync()
+        {
+            // If there are any filenames in InvalidSyncUpFiles, directories can't be synced. 
+            return InvalidSyncUpFiles.Any();
         }
     }
 

--- a/Updater/Server.cs
+++ b/Updater/Server.cs
@@ -290,8 +290,8 @@ public class Server : INotificationHandler
 
                 try
                 {
-                    Server.UpdateUILogs($"Sending files to client and waiting to recieve files from client {clientId}");
-                    communicator.Send(serializedDataPacket, "Server", clientId);
+                    UpdateUILogs($"Sending files to client and waiting to recieve files from client {clientId}");
+                    communicator.Send(serializedDataPacket, "FileTransferHandler", clientId);
 
                     // End the sync up
                     server.CompleteSync();
@@ -319,7 +319,7 @@ public class Server : INotificationHandler
                 {
                     Directory.CreateDirectory(Path.GetDirectoryName(tempFilePath)!);
                     File.WriteAllText(tempFilePath, serializedDifferences);
-                    Server.UpdateUILogs($"Differences file saved to {tempFilePath}");
+                    UpdateUILogs($"Differences file saved to {tempFilePath}");
                     Trace.WriteLine($"[Updater] Differences file saved to {tempFilePath}");
                 }
                 catch (Exception ex)
@@ -369,7 +369,7 @@ public class Server : INotificationHandler
 
                 try
                 {
-                    Server.UpdateUILogs($"Sending files to client and waiting to recieve files from client {clientId}");
+                    UpdateUILogs($"Sending files to client and waiting to recieve files from client {clientId}");
                     communicator.Send(serializedDataPacket, "FileTransferHandler", clientId);
                 }
                 catch (Exception ex)
@@ -395,7 +395,7 @@ public class Server : INotificationHandler
     {
         try
         {
-            Server.UpdateUILogs("Recieved files from client");
+            UpdateUILogs("Recieved files from client");
             // File list
             List<FileContent> fileContentList = dataPacket.FileContentList;
 
@@ -415,7 +415,7 @@ public class Server : INotificationHandler
                 }
             }
 
-            Server.UpdateUILogs("Successfully received client's files");
+            UpdateUILogs("Successfully received client's files");
             Trace.WriteLine("[Updater] Successfully received client's files");
 
             // Broadcast client's new files to all clients
@@ -424,7 +424,7 @@ public class Server : INotificationHandler
             // Serialize packet
             string serializedPacket = Utils.SerializeObject(dataPacket);
 
-            Server.UpdateUILogs("Broadcasting the new files");
+            UpdateUILogs("Broadcasting the new files");
             Trace.WriteLine("[Updater] Broadcasting the new files");
             try
             {
@@ -479,7 +479,7 @@ public class Server : INotificationHandler
             string clientId = $"Client{Interlocked.Increment(ref s_clientCounter)}"; // Use Interlocked for thread safety
 
             Trace.WriteLine($"[Updater] FileTransferHandler detected new client connection: {socket.Client.RemoteEndPoint}, assigned ID: {clientId}");
-            Server.UpdateUILogs($"Detected new client connection: {socket.Client.RemoteEndPoint}, assigned ID: {clientId}");
+            UpdateUILogs($"Detected new client connection: {socket.Client.RemoteEndPoint}, assigned ID: {clientId}");
 
             _clientConnections.Add(clientId, socket); // Add client connection to the dictionary
             _communicator?.AddClient(clientId, socket); // Use the unique client ID
@@ -500,7 +500,7 @@ public class Server : INotificationHandler
         {
             if (_clientConnections.Remove(clientId))
             {
-                Server.UpdateUILogs($"Detected client {clientId} disconnected");
+                UpdateUILogs($"Detected client {clientId} disconnected");
                 Trace.WriteLine($"[Updater] FileTransferHandler detected client {clientId} disconnected");
             }
             else


### PR DESCRIPTION
#### Description
This pull request addresses the following issue:
- When a client-server connection is established, if both the client and server directories contain files with the same filename but different content, the sync operation is halted. A log message is displayed on the client side, indicating which files need to be renamed to proceed with the sync. This version forces client to rename files and trigger manual sync if file conflicts occur during syncing. 

#### Changes Made
- **Feature/Enhancement**:  
  - Added a new variable `InvalidSyncUpFiles` to the `DirectoryMetadataHandler` class to store filenames  of files raising fileconflicts
  - Added a new method, `CheckForSameNameDifferentHash` to the `DirectoryMetadataHandler` class, which checks for files with the same name but different content between the client and server.
  - Added a new packet type to the data packet for sending an invalid sync response to the client. 
- **Refactoring**:  
  - Updated the client and server code to incorporate the new logic for handling file name conflicts during sync operations. This includes modifications to how sync responses are sent from the server to the client.

#### Additional Notes
- This change helps in preventing accidental overwrites when files with the same name but different content are found during synchronization.

#### Checklist
- [x] I have tested my changes locally. 
- [ ] I have added/updated tests to cover my changes. (tests to be added later)
- [x] I have followed the coding standards of this project. (For the DirectoryMetadataHandler and related changes)
